### PR TITLE
Fix/broken phantom tests

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -5,8 +5,9 @@ module.exports = function(config) {
     files: [
       'node_modules/angular/angular.js',
       'node_modules/angular-mocks/angular-mocks.js',
+      'node_modules/phantomjs-polyfill/bind-polyfill.js',
       'src/**/*.js',
-      'test/**/*.js'
+      'test/**/*.spec.js'
     ],
     preprocessors: {
       'src/**/*.js': 'babel',

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "karma-phantomjs-launcher": "^0.2.1",
     "mocha": "^2.2.5",
     "phantomjs": "^1.9.18",
+    "phantomjs-polyfill": "0.0.1",
     "sinon-chai": "^2.8.0"
   }
 }

--- a/test/uiMentionController.spec.js
+++ b/test/uiMentionController.spec.js
@@ -487,13 +487,9 @@ describe('uiMentionController', () => {
     function trigger (el, ev, code) {
       let evt;
 
-      if (code) {
-        evt = $document[0].createEvent('KeyboardEvent');
-        evt.initKeyboardEvent(ev, true, true);
-        evt.keyCode = code;
-      } else {
-        evt = new Event(ev);
-      }
+      evt = $document[0].createEvent('KeyboardEvent');
+      evt.initKeyboardEvent(ev, true, true);
+      evt.keyCode = code;
 
       el[0].dispatchEvent(evt);
 


### PR DESCRIPTION
- Add `fn.proto.bind` polyfill for PhantomJS < 2.0. 
- Remove redundant `new Event` calls. 
  - Never(?) made a difference in the specs. 
  - Didn't fly on PhantomJS versions under 2.0.

The tldr version of it all is that I made a boo-boo and ran all the tests on PhantomJS 2.0, which isn't shipped with the `karma-phantomjs-launcher` package, nor is it released on [npm](https://www.npmjs.com/package/phantomjs). 

Closes #13
