### PR TITLE
Fixed example to use box-shadow instead of border

### DIFF
--- a/example/styles.css
+++ b/example/styles.css
@@ -40,13 +40,13 @@ a {
   padding: 2px;
   z-index: 1;
   color: transparent;
-  white-space: pre-wrap; }
+  white-space: pre-wrap;
+  border: 1px solid transparent;
+  width: 100%; }
   .mention-highlight span {
-    padding: 0 2px;
     border-radius: 3px;
     background: lightblue;
-    border: 1px solid blue;
-    margin: -1px -3px; }
+    box-shadow: 0px 0px 0px 1px blue; }
 
 .dropdown {
   position: absolute;

--- a/example/styles.scss
+++ b/example/styles.scss
@@ -51,13 +51,13 @@ a {
   z-index: 1;
   color: rgba(0,0,0,0);
   white-space: pre-wrap;
+  border: 1px solid rgba(0,0,0,0);
+  width: 100%;
 
   span {
-    padding: 0 2px;
     border-radius: 3px;
     background: lightblue;
-    border: 1px solid blue;
-    margin: -1px -3px;
+    box-shadow: 0px 0px 0px 1px blue;
   }
 }
 


### PR DESCRIPTION
Fix for https://github.com/angular-ui/ui-mention/issues/18, where tags break in an odd way towards the end of the textarea
