### PR TITLE
Move dependencies to dev dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,23 +26,22 @@
     "url": "https://github.com/angular-ui/ui-mention/issues"
   },
   "homepage": "https://github.com/angular-ui/ui-mention#readme",
-  "dependencies": {
+  "dependencies": {},
+  "devDependencies": {
+    "angular": "^1.3.18",
+    "angular-mocks": "^1.3.18",
+    "chai": "^3.2.0",
     "gulp": "^3.9.0",
     "gulp-angular-filesort": "^1.1.1",
     "gulp-babel": "^5.1.0",
     "gulp-concat": "^2.6.0",
     "gulp-ext-replace": "^0.2.0",
     "gulp-load-plugins": "^1.0.0-rc.1",
+    "gulp-ng-annotate": "^2.0.0",
     "gulp-sass": "^2.0.4",
     "gulp-sequence": "^0.4.0",
     "gulp-sourcemaps": "^1.5.2",
-    "gulp-uglify": "^1.2.0"
-  },
-  "devDependencies": {
-    "angular": "^1.3.18",
-    "angular-mocks": "^1.3.18",
-    "chai": "^3.2.0",
-    "gulp-ng-annotate": "^2.0.0",
+    "gulp-uglify": "^1.2.0",
     "karma": "^0.13.9",
     "karma-babel-preprocessor": "^5.2.1",
     "karma-chai": "^0.1.0",


### PR DESCRIPTION
Currently node-sass is causing our CI build to fail as it's trying to install it for this module when doing `npm install`, moving everything to dev dependencies means npm won't try and install it for our app. Thanks!
