### PR TITLE
Use dist/mention.js as main file.

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "angular-ui-mention",
   "version": "0.0.7",
   "description": "Facebook-like @mentions for text inputs built around composability",
-  "main": "src/mention.js",
+  "main": "dist/mention.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },


### PR DESCRIPTION
`src/mention.js` has been renamed to `src/mention.es6.js` which breaks while used with `require()` (browserify). This patch change the main file to `dist/mention.js`
